### PR TITLE
Fixes overwriting output values with dot notation

### DIFF
--- a/src/Value/Container.php
+++ b/src/Value/Container.php
@@ -112,7 +112,7 @@ class Container
         $ref = &$this->values;
 
         foreach ($parts as $i => $part) {
-            if ($i < count($parts) - 1) {
+            if ($i < count($parts) - 1 && (!isset($ref[$part]) || !is_array($ref[$part]))) {
                 $ref[$part] = [];
             }
             $ref = &$ref[$part];


### PR DESCRIPTION
When using multiple dot notations, for example to validate a JSON-API input object:

    { "data": { "type": "pages", "attributes": { "title": "Example Page", "slug": "example-page" } } }

And validating this:

```
$validator = new Validator();
$validator->required('data.type')->equals('pages');
$validator->required('data.attributes.title')->lengthBetween(1, 512);
$validator->required('data.attributes.slug')->lengthBetween(1, 48)->regex('#^[a-z0-9\-]+$#');
$validationResult = $validator->validate($data);
if ($validationResult->isNotValid()) {
    throw new RequestException(new BadRequest(), 400);
}
var_dump($validationResult->getValues());
```

Will result in:
```
array(1) {
  ["data"]=>
  array(1) {
    ["slug"] =>
      string(12) "example-page"
  }
}
```

Because the old code traversed without checking if the key already existed and had contents.