### PR TITLE
Add invalid format tests and extend the version exception message

### DIFF
--- a/src/Rule/Uuid.php
+++ b/src/Rule/Uuid.php
@@ -82,7 +82,9 @@ class Uuid extends Regex
     public function __construct($version = self::UUID_V4)
     {
         if ($version >= (self::UUID_V5 * 2) && $version > 0) {
-            throw new \InvalidArgumentException('Invalid UUID version mask given.');
+            throw new \InvalidArgumentException(
+                'Invalid UUID version mask given. Please choose one of the constants on the Uuid class.'
+            );
         }
 
         $this->version = $version;

--- a/tests/Rule/UuidTest.php
+++ b/tests/Rule/UuidTest.php
@@ -87,6 +87,14 @@ class UuidV4Test extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function incorrectVersionsProvider()
+    {
+        return [
+            [4],
+            [Uuid::UUID_V5 * 2],
+        ];
+    }
+
     /**
      * @dataProvider correctUUIDNIL
      */
@@ -182,9 +190,15 @@ class UuidV4Test extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $result->getMessages());
     }
 
-    public function testThrowsExceptionOnUnknownVersion()
+    /**
+     * @dataProvider incorrectVersionsProvider
+     */
+    public function testThrowsExceptionOnUnknownVersion($version)
     {
-        $this->setExpectedException('\InvalidArgumentException', 'Invalid UUID version mask given.');
+        $this->setExpectedException(
+            '\InvalidArgumentException',
+            'Invalid UUID version mask given. Please choose one of the constants on the Uuid class.'
+        );
         $this->validator->required('guid')->uuid(Uuid::UUID_V5 * 2);
     }
 }


### PR DESCRIPTION
### What?

Some small additions. Instead of asking you to add them, I made this PR :)

This makes the error message bit more explicit, in case some one does run into the fact that `4` is no longer supported.

