### PR TITLE
Test valid format, make valid format default, fix error bug, update docs

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -30,7 +30,7 @@ Particle\Validator tries to provide you the most common validations. An overview
 * [required](#required)(callable $callback)
 * [string](#string)()
 * [url](#url)($schemes = [])
-* [uuid](#uuid)($version = UUID::VALID_FORMAT)
+* [uuid](#uuid)($version = Uuid::VALID_FORMAT)
 
 ## allowEmpty
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -30,7 +30,7 @@ Particle\Validator tries to provide you the most common validations. An overview
 * [required](#required)(callable $callback)
 * [string](#string)()
 * [url](#url)($schemes = [])
-* [uuid](#uuid)($version = 4)
+* [uuid](#uuid)($version = UUID::VALID_FORMAT)
 
 ## allowEmpty
 

--- a/src/Chain.php
+++ b/src/Chain.php
@@ -407,7 +407,7 @@ class Chain
      * @param int $version
      * @return $this
      */
-    public function uuid($version = Rule\Uuid::UUID_V4)
+    public function uuid($version = Rule\Uuid::UUID_VALID)
     {
         return $this->addRule(new Rule\Uuid($version));
     }

--- a/src/Rule/Uuid.php
+++ b/src/Rule/Uuid.php
@@ -52,6 +52,7 @@ class Uuid extends Regex
      * @var array
      */
     protected $versionNames = [
+        self::UUID_VALID => 'valid format',
         self::UUID_NIL => 'NIL',
         self::UUID_V1 => 'v1',
         self::UUID_V2 => 'v2',

--- a/tests/Rule/UuidTest.php
+++ b/tests/Rule/UuidTest.php
@@ -16,6 +16,22 @@ class UuidV4Test extends \PHPUnit_Framework_TestCase
         $this->validator = new Validator();
     }
 
+    public function correctUUIDFormat()
+    {
+        return array(
+            array('00000000-0000-0000-0000-000000000000'),
+            array('05D989B3-A786-E411-80C8-0050568766E4'),
+            array('05D989B3-A786-E411-80C8-0050568766E4'),
+            array('8672e692-b936-e611-80da-0050568766e4'),
+            array('9042c873-ed53-e611-80c6-0050568968d5'),
+            array('9293b566-6011-11e6-8b77-86f30ca893d'),
+            array('9293b566-6011-11e6-8b77-86f30ca893ddd'),
+            array('5c3d167e-6011-11e6-8b77-86f30ca893d3'),
+            array('885e561e-6011-11e6-8b77-86f30ca893d3'),
+            array('9293b566-6011-11e6-8b77-86f30ca893d3'),
+        );
+    }
+
     public function correctUUIDNIL()
     {
         return array(
@@ -112,6 +128,17 @@ class UuidV4Test extends \PHPUnit_Framework_TestCase
     public function testReturnsTrueWhenMatchesUuidV1($uuid)
     {
         $this->validator->required('guid')->uuid(Uuid::UUID_V1);
+        $result = $this->validator->validate(['guid' => $uuid]);
+        $this->assertTrue($result->isValid());
+        $this->assertEquals([], $result->getMessages());
+    }
+
+    /**
+     * @dataProvider correctUUIDFormat
+     */
+    public function testReturnsTrueWhenMatchesUuidFormat($uuid)
+    {
+        $this->validator->required('guid')->uuid(Uuid::UUID_VALID);
         $result = $this->validator->validate(['guid' => $uuid]);
         $this->assertTrue($result->isValid());
         $this->assertEquals([], $result->getMessages());

--- a/tests/Rule/UuidTest.php
+++ b/tests/Rule/UuidTest.php
@@ -24,8 +24,6 @@ class UuidV4Test extends \PHPUnit_Framework_TestCase
             array('05D989B3-A786-E411-80C8-0050568766E4'),
             array('8672e692-b936-e611-80da-0050568766e4'),
             array('9042c873-ed53-e611-80c6-0050568968d5'),
-            array('9293b566-6011-11e6-8b77-86f30ca893d'),
-            array('9293b566-6011-11e6-8b77-86f30ca893ddd'),
             array('5c3d167e-6011-11e6-8b77-86f30ca893d3'),
             array('885e561e-6011-11e6-8b77-86f30ca893d3'),
             array('9293b566-6011-11e6-8b77-86f30ca893d3'),
@@ -204,7 +202,7 @@ class UuidV4Test extends \PHPUnit_Framework_TestCase
      */
     public function testReturnsFalseOnNoMatch($uuid)
     {
-        $this->validator->required('guid')->uuid();
+        $this->validator->required('guid')->uuid(Uuid::UUID_V4);
         $result = $this->validator->validate(['guid' => $uuid]);
         $this->assertFalse($result->isValid());
 


### PR DESCRIPTION
### What?

I did some more small tweaks, with that I think we are ready to merge!

* `UUID::VALID_FORMAT` is not default on the chain too
* Docs updated with `UUID::VALID_FORMAT` as default
* Added `VALID_FORMAT` tests, which lead me to a bug:
* Fixed error message for valid format

### Checklist

- [x] Added unit test for added/fixed code
- [x] Updated the documentation

### Linked issue

https://github.com/particle-php/Validator/pull/145

